### PR TITLE
Support providing node.toml and spec.json paths via cmd arguments

### DIFF
--- a/transferRewardToPayoutKey/transferRewardToPayoutKey.js
+++ b/transferRewardToPayoutKey/transferRewardToPayoutKey.js
@@ -2,8 +2,8 @@ var fs = require('fs');
 var Web3 = require('web3');
 var toml = require('toml');
 
-var tomlPath = '../node.toml';
-var specPath = '../spec.json';
+var tomlPath = process.argv[2] || '../node.toml';
+var specPath = process.argv[3] || '../spec.json';
 
 var config = getConfig();
 


### PR DESCRIPTION
In new setup, `node.toml` and `spec.json` are located **two** levels above the script location. It'll be nice if their paths could be provided via command line arguments.