### PR TITLE
(Fix) additional polling of tx receipt, extended logging and additional error handlers

### DIFF
--- a/transferRewardToPayoutKey/utils/configureWeb3.js
+++ b/transferRewardToPayoutKey/utils/configureWeb3.js
@@ -1,0 +1,27 @@
+const Web3 = require('web3');
+const { errorFinish } = require('./errorResponse');
+
+//configures web3
+function configureWeb3(rpc) {
+	return new Promise((resolve, reject) => {
+		let web3;
+		if (typeof web3 !== 'undefined') web3 = new Web3(web3.currentProvider);
+		else web3 = new Web3(new Web3.providers.HttpProvider(rpc));
+
+		if (!web3) return reject({code: 500, title: "error", message: "web3 is undefined"});
+	
+		web3.eth.net.isListening()
+		.then(function(isListening) {
+			if (!isListening) {
+				var err = {code: 500, title: "Error", message: "check RPC"};
+				return errorFinish(err);
+			}
+
+			resolve(web3);
+		}).catch((err) => {
+			reject(err);
+		});
+	});
+}
+
+module.exports = configureWeb3

--- a/transferRewardToPayoutKey/utils/errorResponse.js
+++ b/transferRewardToPayoutKey/utils/errorResponse.js
@@ -1,0 +1,9 @@
+//finalizes script, if error arised
+function errorFinish(err) {
+	console.log("Something went wrong with transferring reward to payout key");
+	if (err) {
+		console.log(err.message);
+	}
+}
+
+module.exports = errorFinish

--- a/transferRewardToPayoutKey/utils/getConfig.js
+++ b/transferRewardToPayoutKey/utils/getConfig.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+//gets config from ./config.json
+function getConfig() {
+	return new Promise(async (resolve, reject) => {
+		const configPath = '../config.json';
+		fs.access(configPath, fs.F_OK, function(err) {
+		    if (err) {
+		        return reject(err)
+		    } else {
+		    	fs.readFile(configPath, 'utf8', (err, config) => {
+				  if (err) reject(err);
+				  resolve(JSON.parse(config));
+				});
+		    }
+		})
+	});
+}
+
+module.exports = getConfig


### PR DESCRIPTION
- Additional error handlers
- Tx hash in logs
- Polling of tx receipt
- Refactoring: `./utils` folder

Relates to https://github.com/poanetwork/poa-scripts-validator/issues/18