### PR TITLE
(Fix, CORE) Exit script on timeout

### DIFF
--- a/transferRewardToPayoutKey/transferRewardToPayoutKey.js
+++ b/transferRewardToPayoutKey/transferRewardToPayoutKey.js
@@ -12,6 +12,13 @@ var web3;
 var keysManager;
 var polling_id;
 
+var SCRIPT_TIMEOUT_SEC = 500; // 2*50 blocks
+if (SCRIPT_TIMEOUT_SEC) {
+	setTimeout(function () {
+		throw new Error("Script is taking too long to complete (> " + SCRIPT_TIMEOUT_SEC + "sec). Exiting");
+	}, SCRIPT_TIMEOUT_SEC*1000);
+}
+
 transferRewardToPayoutKey();
 
 async function transferRewardToPayoutKey() {


### PR DESCRIPTION
Same as https://github.com/poanetwork/poa-scripts-validator/pull/22, now for CORE

----
**Problem**: If some unexpected problem happens (like the one we had in https://github.com/poanetwork/poa-scripts-validator/issues/18) and tx to transfer reward is not getting mined by the node, the script may hang and not exit. Next hour new process will be started and they will keep accumulating.

**Solution**: Add a timeout that will throw an exception and end the script if it didn't complete within the given time. Web3 expects tx to be mined within 50 blocks. This value converted to seconds can be used as a lower bound on the timeout. For safety, we can double it, and so use 500 seconds.